### PR TITLE
Fixed build error

### DIFF
--- a/tools/check_seapp.c
+++ b/tools/check_seapp.c
@@ -737,6 +737,7 @@ static void handle_options(int argc, char *argv[]) {
 						"Unknown option character `\\x%x'.\n",
 						optopt);
 			}
+			break;
 		default:
 			exit(EXIT_FAILURE);
 		}


### PR DESCRIPTION
This commit fixes build error:
```
external/sepolicy/tools/check_seapp.c:731:7: error: this statement may fall through [-Werror=implicit-fallthrough=]
    if (optopt == 'o' || optopt == 'p')
       ^
```