### PR TITLE
Add audit_read permission to class capability2

### DIFF
--- a/access_vectors
+++ b/access_vectors
@@ -447,6 +447,7 @@ class capability2
 	syslog
 	wake_alarm
 	block_suspend
+	audit_read
 }
 
 #


### PR DESCRIPTION
This is actually just merging an updated file from the AOSP.   I needed this policy functional while porting TWRP to a MediaTek device on the 3.18 kernel.   Commit 3198cb5100e1431808897eaa060ed8813001e2c5 on the AOSP repository.  Original author	Woojung Min <wmin@nvidia.com>