### PR TITLE
Added audit_read permission to class capability2

### DIFF
--- a/access_vectors
+++ b/access_vectors
@@ -447,6 +447,7 @@ class capability2
 	syslog
 	wake_alarm
 	block_suspend
+	audit_read
 }
 
 #


### PR DESCRIPTION
Reflects existing commit in AOSP repo.   audit_read is needed to make TWRP work on Alps ac8227l device running a MediaTek 3.18.22 kernel for which there is currently no publicly available source.   